### PR TITLE
Add structured storage models

### DIFF
--- a/app/locations.py
+++ b/app/locations.py
@@ -24,7 +24,7 @@ def store_location_definition(json_text, data):
     db.session.query(LocationDefinition).delete()
     db.session.commit()
 
-    new_def = LocationDefinition(json_data=json_text)
+    new_def = LocationDefinition(name="imported", json_data=json_text)
     db.session.add(new_def)
     db.session.commit()
 

--- a/app/models.py
+++ b/app/models.py
@@ -2,10 +2,24 @@ from datetime import datetime, timezone
 from sqlalchemy import UniqueConstraint
 from app import db
 
+class Module(db.Model):
+    __tablename__ = "modules"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), unique=True, nullable=False)
+    description = db.Column(db.Text)
+
+    def __repr__(self) -> str:
+        return f"<Module {self.name}>"
+
 class Parts(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     description = db.Column(db.String(200), nullable=False)
+    # Keep legacy free form location text for now
     location = db.Column(db.String(200), nullable=False)
+    # Structured location reference (optional)
+    location_id = db.Column(db.Integer, db.ForeignKey('locations.id'), nullable=True, index=True)
+    location_ref = db.relationship('Location', backref='parts')
     mcmaster_id = db.Column(db.String(15))
     date_created = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     deleted_at = db.Column(db.DateTime, nullable=True)
@@ -14,14 +28,37 @@ class Parts(db.Model):
         return f"<Part {self.id}: {self.description}>"
     
 class Location(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    module = db.Column(db.String(50), nullable=False)
-    level = db.Column(db.String(50), nullable=False)
-    position = db.Column(db.String(50), nullable=False)
+    __tablename__ = "locations"
 
-    __table_args__ = (UniqueConstraint('module', 'level', 'position', name='_module_level_position_uc'),)
+    id = db.Column(db.Integer, primary_key=True)
+    module_id = db.Column(db.Integer, db.ForeignKey('modules.id'), nullable=False, index=True)
+    layer = db.Column(db.String, nullable=False)
+    row = db.Column(db.Integer, nullable=False)
+    column = db.Column(db.String, nullable=False)
+    sub_index = db.Column(db.Integer)
+    multi_slot = db.Column(db.Boolean, default=False)
+    label_text = db.Column(db.Text)
+
+    module_obj = db.relationship('Module', backref='locations')
+
+    location_definition_id = db.Column(db.Integer, db.ForeignKey('location_definitions.id'))
+    definition_ref = db.relationship('LocationDefinition', backref='locations')
+
+    __table_args__ = (
+        UniqueConstraint('module_id', 'layer', 'row', 'column', 'sub_index', name='uix_location'),
+    )
+
+    def __repr__(self) -> str:
+        loc = f"{self.layer}:{self.row}{self.column}"
+        if self.sub_index is not None:
+            loc += f".{self.sub_index}"
+        module_name = self.module_obj.name if self.module_obj else self.module_id
+        return f"<Location {module_name}-{loc}>"
 
 class LocationDefinition(db.Model):
+    __tablename__ = "location_definitions"
+
     id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), unique=True, nullable=False)
     json_data = db.Column(db.Text, nullable=False)
     date_created = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))


### PR DESCRIPTION
## Summary
- add `Module` model for high-level storage units
- refactor `Location` model to reference modules and support sub-locations
- link locations to definitions and parts to locations
- adjust `store_location_definition` to provide a name

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684306eb80448321a6f7cb975deab520